### PR TITLE
only assign kcode if ruby version is < 1.9.0

### DIFF
--- a/lib/korean-string.rb
+++ b/lib/korean-string.rb
@@ -5,7 +5,7 @@
 # http://www.w3c.or.kr/i18n/hangul-i18n/ko-code.html
 # (Thanks to @ntrolls for this)
 
-$KCODE = 'UTF8'
+$KCODE = 'UTF8' unless RUBY_VERSION > '1.9.0'
 
          # ㄱ      ㄲ      ㄴ      ㄷ      ㄸ      ㄹ      ㅁ      ㅂ      
 CHOSUNG = [0x3131, 0x3132, 0x3134, 0x3137, 0x3138, 0x3139, 0x3141, 0x3142,


### PR DESCRIPTION
It seems a bit harsh to give everyone on Ruby v1.9+ the below warning:
`.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/korean-string-0.1.0/lib/korean-string.rb:8: warning: variable $KCODE is no longer effective; ignored`

Check the Ruby version in order to avoid the warning.
`$KCODE = 'UTF8' unless RUBY_VERSION > '1.9.0`